### PR TITLE
Add Debug false for production

### DIFF
--- a/message_board/settings.py
+++ b/message_board/settings.py
@@ -26,7 +26,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = "django-insecure-l^+uh-m5%vpahn+kj=^6&a+77f4v8(xx^vrf7m8&130hm_#r#("
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ["DEBUG"]
 
 if not DEBUG:
 


### PR DESCRIPTION
Updated setting for Debug for production to use config var (DEBUG=False) set on heroku for message-board-samso. If everything goes as expected http should be redirected to https than...