### PR TITLE
Add open graph meta tags for meta description

### DIFF
--- a/map/templates/map/default.html
+++ b/map/templates/map/default.html
@@ -2,6 +2,7 @@
 {% block title %}Map{% endblock %}
 {% block seo %}
     <meta name="description"
+          property="og:description"
           content="On this page you find a map of the island of Samsø marking the location of the Energy Academy.">
 {% endblock %}
 {% block content %}

--- a/post/templates/post/add_comment.html
+++ b/post/templates/post/add_comment.html
@@ -1,7 +1,10 @@
 {% extends 'post/base.html' %}
 {% block title %}New Comment{% endblock %}
-{% block seo %}<meta name="description"
-      content="On this page you can add a new comment to a post.">{% endblock %}
+{% block seo %}
+    <meta name="description"
+          property="og:description"
+          content="On this page you can add a new comment to a post.">
+{% endblock %}
 {% block content %}
     {% load crispy_forms_tags %}
     <div class="container">

--- a/post/templates/post/add_post.html
+++ b/post/templates/post/add_post.html
@@ -1,5 +1,9 @@
 {% extends 'post/base.html' %}
-{% block seo %}<meta name="description" content="On this page you can add a new post.">{% endblock %}
+{% block seo %}
+    <meta name="description"
+          property="og:description"
+          content="On this page you can add a new post.">
+{% endblock %}
 {% block title %}Add a Post{% endblock %}
 {% block content %}
     {% load crispy_forms_tags %}

--- a/post/templates/post/base.html
+++ b/post/templates/post/base.html
@@ -7,8 +7,11 @@
         <title>
             {% block title %}Message Board{% endblock %}
         </title>
-        {% block seo %}<meta name="description"
-      content="This is a message board for the danish island Samsø.">{% endblock %}
+        {% block seo %}
+            <meta name="description"
+                  property="og:description"
+                  content="This is a message board for the danish island Samsø.">
+        {% endblock %}
         <!-- Bootstrap5 css -->
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
               rel="stylesheet"

--- a/post/templates/post/delete_comment.html
+++ b/post/templates/post/delete_comment.html
@@ -1,6 +1,10 @@
 {% extends 'post/base.html' %}
 {% block title %}Delete a Comment{% endblock %}
-{% block seo %}<meta name="description" content="On this page you can delete a comment.">{% endblock %}
+{% block seo %}
+    <meta name="description"
+          property="og:description"
+          content="On this page you can delete a comment.">
+{% endblock %}
 {% block content %}
     <div class="container">
         <div class="row d-flex justify-content-center mt-5">

--- a/post/templates/post/delete_post.html
+++ b/post/templates/post/delete_post.html
@@ -1,6 +1,10 @@
 {% extends 'post/base.html' %}
 {% block title %}Delete a Post{% endblock %}
-{% block seo %}<meta name="description" content="On this page you can delete a post.">{% endblock %}
+{% block seo %}
+    <meta name="description"
+          property="og:description"
+          content="On this page you can delete a post.">
+{% endblock %}
 {% block content %}
     <div class="container">
         <div class="row d-flex justify-content-center mt-5">

--- a/post/templates/post/home.html
+++ b/post/templates/post/home.html
@@ -1,7 +1,10 @@
 {% extends 'post/base.html' %}
 {% block title %}Latest Posts{% endblock %}
-{% block seo %}<meta name="description"
-      content="On this page you have an overview of the latest posts.">{% endblock %}
+{% block seo %}
+    <meta name="description"
+          property="og:description"
+          content="On this page you have an overview of the latest posts.">
+{% endblock %}
 {% block content %}
     <div class="container mt-5">
         <h1 class="my-3 text-center" id="heading">Latest Posts</h1>

--- a/post/templates/post/post.html
+++ b/post/templates/post/post.html
@@ -2,6 +2,7 @@
 {% block title %}{{ post.title }}{% endblock %}
 {% block seo %}
     <meta name="description"
+          property="og:description"
           content="On this detail page you find a post with complete text.">
 {% endblock %}
 {% block content %}

--- a/post/templates/post/search.html
+++ b/post/templates/post/search.html
@@ -1,7 +1,10 @@
 {% extends "post/base.html" %}
 {% block title %}Search Results{% endblock %}
-{% block seo %}<meta name="description"
-      content="On this page you find the results for your search.">{% endblock %}
+{% block seo %}
+    <meta name="description"
+          property="og:description"
+          content="On this page you find the results for your search.">
+{% endblock %}
 {% block header %}Search{% endblock %}
 {% block content %}
     <div class="container mt-5">

--- a/post/templates/post/update_comment.html
+++ b/post/templates/post/update_comment.html
@@ -1,6 +1,10 @@
 {% extends 'post/base.html' %}
 {% block title %}Update a Comment{% endblock %}
-{% block seo %}<meta name="description" content="On this page you can update a comment.">{% endblock %}
+{% block seo %}
+    <meta name="description"
+          property="og:description"
+          content="On this page you can update a comment.">
+{% endblock %}
 {% block content %}
     {% load crispy_forms_tags %}
     <div class="container">

--- a/post/templates/post/update_post.html
+++ b/post/templates/post/update_post.html
@@ -1,6 +1,10 @@
 {% extends 'post/base.html' %}
 {% block title %}Update a Post{% endblock %}
-{% block seo %}<meta name="description" content="On this page you can update a post.">{% endblock %}
+{% block seo %}
+    <meta name="description"
+          property="og:description"
+          content="On this page you can update a post.">
+{% endblock %}
 {% block content %}
     {% load crispy_forms_tags %}
     <div class="container">

--- a/user/templates/user/delete_user.html
+++ b/user/templates/user/delete_user.html
@@ -2,6 +2,7 @@
 {% block title %}Delete Profile{% endblock %}
 {% block seo %}
     <meta name="description"
+          property="og:description"
           content="On this page you can delete your profile and all related posts.">
 {% endblock %}
 {% block content %}

--- a/user/templates/user/login.html
+++ b/user/templates/user/login.html
@@ -1,7 +1,10 @@
 {% extends 'post/base.html' %}
 {% block title %}Login{% endblock %}
-{% block seo %}<meta name="description"
-      content="On this page you can login with username and password.">{% endblock %}
+{% block seo %}
+    <meta name="description"
+          property="og:description"
+          content="On this page you can login with username and password.">
+{% endblock %}
 {% block content %}
     {% load crispy_forms_tags %}
     <div class="container">

--- a/user/templates/user/logout.html
+++ b/user/templates/user/logout.html
@@ -2,6 +2,7 @@
 {% block title %}Logout{% endblock %}
 {% block seo %}
     <meta name="description"
+          property="og:description"
           content="This page displays that you have been logged out and can login again.">
 {% endblock %}
 {% block content %}

--- a/user/templates/user/profile.html
+++ b/user/templates/user/profile.html
@@ -2,6 +2,7 @@
 {% block title %}Profile{% endblock %}
 {% block seo %}
     <meta name="description"
+          property="og:description"
           content="This page displays your profile with username, email, phone and the option to edit the profile.">
 {% endblock %}
 {% block content %}

--- a/user/templates/user/register.html
+++ b/user/templates/user/register.html
@@ -2,6 +2,7 @@
 {% block title %}Register{% endblock %}
 {% block seo %}
     <meta name="description"
+          property="og:description"
           content="On this page you can register with username, email, password and address.">
 {% endblock %}
 {% block content %}

--- a/user/templates/user/update_profile.html
+++ b/user/templates/user/update_profile.html
@@ -1,6 +1,10 @@
 {% extends 'post/base.html' %}
 {% block title %}Update Profile{% endblock %}
-{% block seo %}<meta name="description" content="On this page you can update you profile.">{% endblock %}
+{% block seo %}
+    <meta name="description"
+          property="og:description"
+          content="On this page you can update you profile.">
+{% endblock %}
 {% block content %}
     {% load crispy_forms_tags %}
     <div class="container">


### PR DESCRIPTION
Open Graph meta tags are snippets of code that control how URLs are displayed when shared on social media. 

They’re part of Facebook’s [Open Graph protocol](https://ogp.me/) and are also used by other social media sites, including LinkedIn and Twitter (if Twitter Cards are absent).

People are arguably more likely to see and click shared content with optimized OG tags, which means more social media traffic to your website.

There are three reasons for this:
- They make content more eye-catching in social media feeds.
- They tell people what the content is about at a glance.
- They help Facebook understand what the content is about, which can help increase your brand visibility through search.